### PR TITLE
feat: update slack channel link and participant team

### DIFF
--- a/data-task.html
+++ b/data-task.html
@@ -295,7 +295,7 @@
                   <path d="M13 2.5a1.5 1.5 0 0 1 3 0v11a1.5 1.5 0 0 1-3 0v-11zm-1 .724c-2.067.95-4.539 1.481-7 1.656v6.237a25.222 25.222 0 0 1 1.088.085c2.053.204 4.038.668 5.912 1.56V3.224zm-8 7.841V4.934c-.68.027-1.399.043-2.008.053A2.02 2.02 0 0 0 0 7v2c0 1.106.896 1.996 1.994 2.009a68.14 68.14 0 0 1 .496.008 64 64 0 0 1 1.51.048zm1.39 1.081c.285.021.569.047.85.078l.253 1.69a1 1 0 0 1-.983 1.187h-.548a1 1 0 0 1-.916-.599l-1.314-2.48a65.81 65.81 0 0 1 1.692.064c.327.017.65.037.966.06z"/>
                 </svg>
                 Paper submissions will open on the 11th of June (read more below!)</a></b></font></p>
-            <p>&nbsp;&nbsp;&nbsp;&nbsp;<font size="4"><b><a href="https://join.slack.com/t/ecom-ir/shared_invite/zt-18soqtof7-NvU1cbmEcYudluhmYlQ3Mg" target="_blank">
+            <p>&nbsp;&nbsp;&nbsp;&nbsp;<font size="4"><b><a href="https://join.slack.com/t/ecom-ir/shared_invite/zt-1b9zohll0-D0HgTK94DlqCNslsrHiFDw" target="_blank">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-slack" viewBox="0 0 16 16">
                   <path d="M3.362 10.11c0 .926-.756 1.681-1.681 1.681S0 11.036 0 10.111C0 9.186.756 8.43 1.68 8.43h1.682v1.68zm.846 0c0-.924.756-1.68 1.681-1.68s1.681.756 1.681 1.68v4.21c0 .924-.756 1.68-1.68 1.68a1.685 1.685 0 0 1-1.682-1.68v-4.21zM5.89 3.362c-.926 0-1.682-.756-1.682-1.681S4.964 0 5.89 0s1.68.756 1.68 1.68v1.682H5.89zm0 .846c.924 0 1.68.756 1.68 1.681S6.814 7.57 5.89 7.57H1.68C.757 7.57 0 6.814 0 5.89c0-.926.756-1.682 1.68-1.682h4.21zm6.749 1.682c0-.926.755-1.682 1.68-1.682.925 0 1.681.756 1.681 1.681s-.756 1.681-1.68 1.681h-1.681V5.89zm-.848 0c0 .924-.755 1.68-1.68 1.68A1.685 1.685 0 0 1 8.43 5.89V1.68C8.43.757 9.186 0 10.11 0c.926 0 1.681.756 1.681 1.68v4.21zm-1.681 6.748c.926 0 1.682.756 1.682 1.681S11.036 16 10.11 16s-1.681-.756-1.681-1.68v-1.682h1.68zm0-.847c-.924 0-1.68-.755-1.68-1.68 0-.925.756-1.681 1.68-1.681h4.21c.924 0 1.68.756 1.68 1.68 0 .926-.756 1.681-1.68 1.681h-4.21z"/>
                 </svg>
@@ -328,7 +328,7 @@
             <table class="table results-table">
               <tbody>
                 <tr><th>Rank</th><th>Participant team</th><th>FITB</th></tr>
-                <tr><td>1</td><td>cottagecore</td><td>0.799</td></tr>
+                <tr><td>1</td><td>Depop</td><td>0.799</td></tr>
                 <tr><td>2</td><td>Outfit>Overfit</td><td>0.764</td></tr>
                 <tr><td>3</td><td>SefaMerve Research</td><td>0.680</td></tr>
                 <tr><td>4</td><td>ColdWheels</td><td>0.660</td></tr>


### PR DESCRIPTION
This PR updates the Slack channel link, which had expired. In addition, it also renames the participant team name.